### PR TITLE
Add time-based randomness for motors

### DIFF
--- a/simulator/modules/sbot_interface/devices/motor.py
+++ b/simulator/modules/sbot_interface/devices/motor.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 
 from sbot_interface.devices.util import (
     WebotsDevice,
-    add_jitter,
+    add_motor_jitter,
     get_globals,
     get_robot_device,
     map_to_range,
@@ -112,7 +112,17 @@ class Motor(BaseMotor):
         if value != 0:
             # Apply a small amount of variation to the power setting to simulate
             # inaccuracies in the motor
-            value = int(add_jitter(value, (MIN_POWER, MAX_POWER)))
+            name = self._device.getName()
+            value = int(add_motor_jitter(
+                value,
+                (MIN_POWER, MAX_POWER),
+                name,
+                get_globals().robot.getTime(),
+                std_dev_percent = 5
+            ))
+            # value = int(add_jitter(value, (MIN_POWER, MAX_POWER)))
+            # if "left" in name:
+            print(f"{name}: {value}, err_factor: {((value-85) % 100) * ('-' if 'left' in name else '+')}")
 
         self._device.setVelocity(map_to_range(
             value,

--- a/simulator/modules/sbot_interface/devices/motor.py
+++ b/simulator/modules/sbot_interface/devices/motor.py
@@ -120,9 +120,6 @@ class Motor(BaseMotor):
                 get_globals().robot.getTime(),
                 std_dev_percent = 5
             ))
-            # value = int(add_jitter(value, (MIN_POWER, MAX_POWER)))
-            # if "left" in name:
-            print(f"{name}: {value}, err_factor: {((value-85) % 100) * ('-' if 'left' in name else '+')}")
 
         self._device.setVelocity(map_to_range(
             value,


### PR DESCRIPTION
The problem: 

Some teams (especially one that rhymes with "phills toad snick four-m crawlage") have found that if they set the motor speed every tick, the jitter we add to the speed actually averages out and the robot drives perfectly straight.

So, instead of picking a random number every frame, we instead pick one every second. We then LERP between these values roughly every second, so the robots don't lurch around.

Here's a video where the robot motor power is set to `1.0` every 0.05s, without me adjusting the camera angle:

https://github.com/user-attachments/assets/3d96d232-3e98-4bc1-a3ff-0a7f007ce76b

The console is printing a debug message that shows the power of each motor, see how they slowly ramp between values. (modulo a random number)

Maybe we want to consider removing the value cap for the jitter, but I won't do that here.